### PR TITLE
Prevent Discord from not updating when state/details are not set #14

### DIFF
--- a/src/main/java/com/github/psnrigner/discordrpcjava/DiscordRichPresence.java
+++ b/src/main/java/com/github/psnrigner/discordrpcjava/DiscordRichPresence.java
@@ -361,8 +361,12 @@ public class DiscordRichPresence
         args.add("pid", new JsonPrimitive(pid));
 
         JsonObject activity = new JsonObject();
-        activity.add("state", new JsonPrimitive(this.getState()));
-        activity.add("details", new JsonPrimitive(this.getDetails()));
+        
+        if (!this.getState().trim().isEmpty())
+        	activity.add("state", new JsonPrimitive(this.getState()));
+
+        if (!this.getDetails().trim().isEmpty())
+        	activity.add("details", new JsonPrimitive(this.getDetails()));
 
         if (this.getStartTimestamp() != 0 || this.getEndTimestamp() != 0)
         {


### PR DESCRIPTION
Ensure that state and details are not empty strings before adding them to the JSON.
Discord won't update itself if one of them is empty.